### PR TITLE
[CLOUD-7277] Pass moderation details as part of ModerationException

### DIFF
--- a/iointel/src/agent_methods/data_models/datamodels.py
+++ b/iointel/src/agent_methods/data_models/datamodels.py
@@ -446,12 +446,6 @@ class TranslationResult(BaseModel):
 Activation = Annotated[float, Field(ge=0, le=1)]
 
 
-class ModerationException(Exception):
-    """Exception raised when a message is not allowed."""
-
-    ...
-
-
 class ViolationActivation(TypedDict):
     """Violation activation."""
 
@@ -461,6 +455,14 @@ class ViolationActivation(TypedDict):
     harassment: Activation
     self_harm: Activation
     dangerous_content: Activation
+
+
+class ModerationException(Exception):
+    """Exception raised when a message is not allowed."""
+
+    def __init__(self, *args, violations: ViolationActivation):
+        super().__init__(*args)
+        self.violations = violations
 
 
 ##### task and workflow models ########

--- a/iointel/src/chainables.py
+++ b/iointel/src/chainables.py
@@ -225,17 +225,19 @@ async def execute_moderation(
         ).execute()
 
         if result["extreme_profanity"] > threshold:
-            raise ModerationException("Extreme profanity detected")
+            raise ModerationException("Extreme profanity detected", violations=result)
         elif result["sexually_explicit"] > threshold:
-            raise ModerationException("Sexually explicit content detected")
+            raise ModerationException(
+                "Sexually explicit content detected", violations=result
+            )
         elif result["hate_speech"] > threshold:
-            raise ModerationException("Hate speech detected")
+            raise ModerationException("Hate speech detected", violations=result)
         elif result["harassment"] > threshold:
-            raise ModerationException("Harassment detected")
+            raise ModerationException("Harassment detected", violations=result)
         elif result["self_harm"] > threshold:
-            raise ModerationException("Self harm detected")
+            raise ModerationException("Self harm detected", violations=result)
         elif result["dangerous_content"] > threshold:
-            raise ModerationException("Dangeme profanity detected")
+            raise ModerationException("Dangeme profanity detected", violations=result)
 
         return result
 


### PR DESCRIPTION
Part of fixing [CLOUD-7277](https://linear.app/ionet/issue/CLOUD-7277/moderation-agent-is-throwing-500)