### PR TITLE
Allow overriding task type in workflow, default to `custom`

### DIFF
--- a/iointel/src/agent_methods/data_models/datamodels.py
+++ b/iointel/src/agent_methods/data_models/datamodels.py
@@ -552,6 +552,7 @@ WhileStage.model_rebuild()
 class TaskDefinition(BaseModel):
     task_id: str
     name: str
+    type: str = "custom"
     # description: Optional[str] = None
     objective: Optional[str] = None
     agents: Optional[Union[List[AgentParams], AgentSwarm]] = None

--- a/iointel/src/chainables.py
+++ b/iointel/src/chainables.py
@@ -261,16 +261,16 @@ def execute_custom(
 
             return custom_workflow(
                 name=name,
-                objective=task_metadata["objective"],
+                objective=objective,
                 agents=agents,
-                context={**task_metadata.get("kwargs", {}), "text": objective},
+                context=task_metadata.get("kwargs", {}),
             )
         else:
             response = run_agents(
                 name=name,
-                objective=task_metadata["objective"],
+                objective=objective,
                 agents=agents,
-                context={"text": objective, **task_metadata.get("kwargs", {})},
+                context=task_metadata.get("kwargs", {}),
                 output_type=str,
             )
             return response.execute()
@@ -399,8 +399,8 @@ def custom(
     self.tasks.append(
         {
             "type": "custom",
-            "objective": self.objective,
-            "task_metadata": {"name": name, "objective": objective, "kwargs": kwargs},
+            "objective": objective,
+            "task_metadata": {"name": name, "kwargs": kwargs},
             "agents": self.agents if agents is None else agents,
         }
     )

--- a/iointel/src/workflow.py
+++ b/iointel/src/workflow.py
@@ -430,6 +430,7 @@ class Workflow:
                 task_metadata["client_mode"] = t.get("client_mode", self.client_mode)
             task_model = TaskDefinition(
                 task_id=t.get("task_id", t.get("type", str(uuid.uuid4()))),
+                type=t.get("type", "custom"),
                 name=t.get("name", t.get("type", "Unnamed Task")),
                 objective=t.get("objective"),
                 task_metadata=task_metadata,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -27,9 +27,10 @@ def test_tasks_custom():
         objective="Custom objective",
         my_extra="something",
     )
+    assert flows.objective == "Analyze this text"
     assert len(flows.tasks) == 1
     c = flows.tasks[0]
     assert c["type"] == "custom"
+    assert c["objective"] == "Custom objective"
     assert c["task_metadata"]["name"] == "my-custom-step"
-    assert c["task_metadata"]["objective"] == "Custom objective"
     assert c["task_metadata"]["kwargs"]["my_extra"] == "something"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -217,9 +217,6 @@ def test_yaml_roundtrip(custom_hi_task, poet, store_creds: bool):
         base_noagent = dict(base, agents=None)
         unpacked_noagent = dict(unpacked, agents=None)
         for key, value in base_noagent.items():
-            # FIXME: remove the skip when task type is overridable
-            if key == "type":
-                continue
             assert unpacked_noagent[key] == value, (
                 "Expected roundtrip to retain task info"
             )


### PR DESCRIPTION
Also fix discrepancy in how custom_task worked with `objective` compared to others