### PR TITLE
Fix google_calendar.py to use wrap_tool pattern

### DIFF
--- a/iointel/src/agent_methods/tools/agno/google_calendar.py
+++ b/iointel/src/agent_methods/tools/agno/google_calendar.py
@@ -1,9 +1,7 @@
 from typing import Optional, List
-from functools import wraps
 from agno.tools.googlecalendar import GoogleCalendarTools as AgnoGoogleCalendarTools
 
-from ..utils import register_tool
-from .common import DisableAgnoRegistryMixin
+from .common import DisableAgnoRegistryMixin, wrap_tool
 
 
 class GoogleCalendar(DisableAgnoRegistryMixin, AgnoGoogleCalendarTools):
@@ -12,14 +10,12 @@ class GoogleCalendar(DisableAgnoRegistryMixin, AgnoGoogleCalendarTools):
     ):
         super().__init__(credentials_path=credentials_path, token_path=token_path)
 
-    @register_tool(name="google_calendar_list_events")
-    @wraps(AgnoGoogleCalendarTools.list_events)
+    @wrap_tool("google_calendar_list_events", AgnoGoogleCalendarTools.list_events)
     def list_events(self, limit: int = 10, date_from: str = None) -> str:
         # return self._tools.list_events(limit=limit, date_from=date_from)
         return super().list_events(limit=limit, date_from=date_from)
 
-    @register_tool(name="google_calendar_create_event")
-    @wraps(AgnoGoogleCalendarTools.create_event)
+    @wrap_tool("google_calendar_create_event", AgnoGoogleCalendarTools.create_event)
     def create_event(
         self,
         start_datetime: str,


### PR DESCRIPTION
Update GoogleCalendar tool to use wrap_tool decorator pattern consistent with other agno tools. This preserves the correct __qualname__ attribute for better tool class discovery.